### PR TITLE
fix: correct JNLP path and installations

### DIFF
--- a/maven/jdk11/Dockerfile
+++ b/maven/jdk11/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/inbound-agent:alpine as jnlp
+# Use Debian base
+FROM jenkins/inbound-agent:jdk11 as jnlp
 
 FROM maven:3.8.2-eclipse-temurin-11
 

--- a/maven/jdk8/Dockerfile
+++ b/maven/jdk8/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/inbound-agent:alpine as jnlp
+# Use Debian base
+FROM jenkins/inbound-agent:jdk8 as jnlp
 
 FROM maven:3.8.2-eclipse-temurin-8
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:alpine as jnlp
+FROM jenkins/inbound-agent:alpine-jdk11 as jnlp
 
 FROM node:alpine
 
@@ -7,7 +7,7 @@ FROM node:alpine
 RUN apk --no-cache add bash git
 
 # Install JDK from the official agent image
-ENV JAVA_HOME=/opt/jdk11
+ENV JAVA_HOME=/opt/jdk-11
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jnlp /opt/java/openjdk "${JAVA_HOME}"
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/inbound-agent:alpine as jnlp
+# Use debian base
+FROM jenkins/inbound-agent:jdk11 as jnlp
 
 FROM ruby:2-stretch
 
@@ -12,7 +13,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install JDK from the official agent image
-ENV JAVA_HOME=/opt/jdk11
+ENV JAVA_HOME=/opt/jdk-11
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jnlp /opt/java/openjdk "${JAVA_HOME}"
 


### PR DESCRIPTION
- First of all, the expected JDK are `/op/jdk-11` etc. (not blocking but better to have the same everywhere...). Ref. https://github.com/jenkins-infra/packer-images/blob/main/scripts/ubuntu-20-provision.sh#L113
- Second, the ruby image is currently broken, because the (statically linked by jlink) JDK comes from alpine while the ruby image is debian-based, resulting in failure to spawn containers.
- Third: it's easier to have explciit JDK and OS versions (at least for alpine), even if not always used.