### PR TITLE
feat: activate semver

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -3,7 +3,8 @@ parallel(
   'maven-jdk8': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk8', [
       dockerfile: 'maven/jdk8/Dockerfile',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'maven-jdk8-nanoserver': {
@@ -11,13 +12,15 @@ parallel(
       dockerfile: 'maven/jdk8/Dockerfile.nanoserver',
       agentLabels: 'windows',
       platform: 'windows/amd64',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'maven-jdk11': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk11', [
       dockerfile: 'maven/jdk11/Dockerfile',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'maven-jdk11-nanoserver': {
@@ -25,13 +28,15 @@ parallel(
       dockerfile: 'maven/jdk11/Dockerfile.nanoserver',
       agentLabels: 'windows',
       platform: 'windows/amd64',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'maven-jdk17': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk17', [
       dockerfile: 'maven/jdk17/Dockerfile',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'jdk11-windowsservercore-1809': {
@@ -39,20 +44,22 @@ parallel(
       dockerfile: 'base/jdk11/Dockerfile.windowsservercore-1809',
       agentLabels: 'windows',
       platform: 'windows/amd64',
-      useContainer: false,
       automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'node': {
      buildDockerAndPublishImage('inbound-agent-node', [
       dockerfile: 'node/Dockerfile',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'ruby': {
      buildDockerAndPublishImage('inbound-agent-ruby', [
       dockerfile: 'ruby/Dockerfile',
-      useContainer: false,
+      automaticSemanticVersioning: true,
+      multipleSemverImagesBuild: true,
     ])
   },
   'updatecli': {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,7 +6,7 @@ parallel(
      buildDockerAndPublishImage('inbound-agent-maven:jdk8', [
       dockerfile: 'maven/jdk8/Dockerfile',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'maven-jdk8-nanoserver': {
@@ -15,14 +15,14 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'maven-jdk11': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk11', [
       dockerfile: 'maven/jdk11/Dockerfile',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'maven-jdk11-nanoserver': {
@@ -31,14 +31,14 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'maven-jdk17': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk17', [
       dockerfile: 'maven/jdk17/Dockerfile',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'jdk11-windowsservercore-1809': {
@@ -47,21 +47,21 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'node': {
      buildDockerAndPublishImage('inbound-agent-node', [
       dockerfile: 'node/Dockerfile',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'ruby': {
      buildDockerAndPublishImage('inbound-agent-ruby', [
       dockerfile: 'ruby/Dockerfile',
       automaticSemanticVersioning: true,
-      includeStageNameInTag: true,
+      includeImageNameInTag: true,
     ])
   },
   'updatecli': {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,10 +1,12 @@
+@Library('pipeline-library@pull/400/head') _
+
 parallel(
   failFast: false,
   'maven-jdk8': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk8', [
       dockerfile: 'maven/jdk8/Dockerfile',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'maven-jdk8-nanoserver': {
@@ -13,14 +15,14 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'maven-jdk11': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk11', [
       dockerfile: 'maven/jdk11/Dockerfile',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'maven-jdk11-nanoserver': {
@@ -29,14 +31,14 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'maven-jdk17': {
      buildDockerAndPublishImage('inbound-agent-maven:jdk17', [
       dockerfile: 'maven/jdk17/Dockerfile',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'jdk11-windowsservercore-1809': {
@@ -45,21 +47,21 @@ parallel(
       agentLabels: 'windows',
       platform: 'windows/amd64',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'node': {
      buildDockerAndPublishImage('inbound-agent-node', [
       dockerfile: 'node/Dockerfile',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'ruby': {
      buildDockerAndPublishImage('inbound-agent-ruby', [
       dockerfile: 'ruby/Dockerfile',
       automaticSemanticVersioning: true,
-      multipleSemverImagesBuild: true,
+      includeStageNameInTag: true,
     ])
   },
   'updatecli': {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/400/head') _
-
 parallel(
   failFast: false,
   'maven-jdk8': {


### PR DESCRIPTION
cleanup: remove useContainer as img is deprecated

Follow-up of https://github.com/jenkins-infra/pipeline-library/pull/399 and https://github.com/jenkins-infra/pipeline-library/pull/398