### PR TITLE
feat(ruby) bump Ruby to 2.6.10

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,7 +1,7 @@
 # Use debian base
 FROM jenkins/inbound-agent:jdk11 as jnlp
 
-FROM ruby:2-stretch
+FROM ruby:2.6
 
 ## Ignore apt package pinning as we always want the latest package here
 # hadolint ignore=DL3008


### PR DESCRIPTION
This PR comes from https://github.com/jenkins-infra/jenkins-infra/pull/2263 where we have to install `yq`.

First, let's use a "decent" version of the Ruby image.

- 2.6.10 is (and will be) the final version of 2.6 baseline of ruby (https://github.com/jenkins-infra/jenkins-infra/issues/2247)
- Using the `slim` image instead of `stretch` to avoid depending on a given distribution