### PR TITLE
fix(maven-8 windows) correct JDK11 path to use the same value as packer-images 

### DIFF
--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -5,4 +5,4 @@ FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 FROM jenkins/jnlp-agent-maven:windows-nanoserver AS jnlp
 
 # Retrieve JDK11 for running jenkins agent process but do not use it as default
-COPY --from=core C:/openjdk-11 C:/openjdk-11
+COPY --from=core C:/openjdk-11 C:/tools/jdk-11


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/packer-images/blob/006ef860004c8d2d508a06c89279aa072f8c105f/provisioning/windows-provision.ps1\#L106
