### PR TITLE
feat(maven-windows) bump Maven to 3.8.6, JDK11 to 11.0.16.1 and JDK8 to 1.8.0_332

### DIFF
--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -14,5 +14,5 @@ RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:
   Remove-Item ${env:TEMP}/apache-maven.zip ;
 
 ENV JAVA_HOME ${JAVA_HOME}
-ENV MAVEN_HOME "C:/tools/apache-maven-${MAVEN_VERSION}"
+ENV MAVEN_HOME "C:\tools\apache-maven-${MAVEN_VERSION}"
 ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;${MAVEN_HOME}\bin"

--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,2 +1,21 @@
 # Use https://github.com/jenkinsci/jnlp-agents as base for now
-FROM jenkins/jnlp-agent-maven:windows-nanoserver-jdk11 AS jnlp
+# FROM jenkins/jnlp-agent-maven:windows-nanoserver-jdk11 AS jnlp
+
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:1809 as core
+FROM jenkins/inbound-agent:jdk11-nanoserver-1809
+
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
+COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+
+ARG MAVEN_VERSION=3.8.6
+RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `
+  Expand-Archive -Path "${env:TEMP}/apache-maven.zip -Destination" C:\tools ; `
+  Remove-Item ${env:TEMP}/apache-maven.zip ;
+
+ENV JAVA_HOME ${JAVA_HOME}
+ENV MAVEN_HOME "C:/tools/apache-maven-${MAVEN_VERSION}"
+ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;${MAVEN_HOME}\bin"

--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,6 +1,3 @@
-# Use https://github.com/jenkinsci/jnlp-agents as base for now
-# FROM jenkins/jnlp-agent-maven:windows-nanoserver-jdk11 AS jnlp
-
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:1809 as core
 FROM jenkins/inbound-agent:jdk11-nanoserver-1809

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,8 +1,18 @@
-ARG JAVA_VERSION="11.0.16_8"
-FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:1809 as core
+FROM jenkins/inbound-agent:jdk8-nanoserver-1809
 
-# Use https://github.com/jenkinsci/jnlp-agents as base for now
-FROM jenkins/jnlp-agent-maven:windows-nanoserver AS jnlp
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve JDK11 for running jenkins agent process but do not use it as default
-COPY --from=core C:/openjdk-11 C:/tools/jdk-11
+# https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
+COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+
+ARG MAVEN_VERSION=3.8.6
+RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `
+  Expand-Archive -Path "${env:TEMP}/apache-maven.zip -Destination" C:\tools ; `
+  Remove-Item ${env:TEMP}/apache-maven.zip ;
+
+ENV JAVA_HOME ${JAVA_HOME}
+ENV MAVEN_HOME "C:/tools/apache-maven-${MAVEN_VERSION}"
+ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;${MAVEN_HOME}\bin"

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -14,5 +14,5 @@ RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:
   Remove-Item ${env:TEMP}/apache-maven.zip ;
 
 ENV JAVA_HOME ${JAVA_HOME}
-ENV MAVEN_HOME "C:/tools/apache-maven-${MAVEN_VERSION}"
+ENV MAVEN_HOME "C:\tools\apache-maven-${MAVEN_VERSION}"
 ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;${MAVEN_HOME}\bin"


### PR DESCRIPTION
- The windows containers on ci.jenkins.io are using this image
- We haven't updated these images since 3 month (because the parent image jenkins/jnlp-agent-maven hasn't been updated): Maven was still 3.8.4 and the JDK are old
- We thought that we could land the "all-in-one" image but https://github.com/jenkins-infra/packer-images/pull/321 is not finished: hence this PR to bumpd the JDK and Maven versions of the Window Maven images

This PR also introduces a few changes to the previous version:

- Default container user is now `jenkins`, and its default user home is `C:\Users\jenkins`

Please note that, since these images are using `nanoserver`, then the default Java system property `user.home` defaults to `C:` which causes the default Maven local repository to be in `C:\.m2`.
There isn't really at the image level, except either:

- Switching to Windows Server Core the base image (=> worth working on the all in one container then)
- Explictly set the `user.home` property

This PR is a first steps towards improvement let's review and ship it before going further