### PR TITLE
fix(maven-8-windows) JDK11 is required for agent

### DIFF
--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,9 +1,13 @@
 # escape=`
-FROM mcr.microsoft.com/windows/servercore:1809 as core
+ARG JAVA_VERSION="11.0.16_8"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 FROM jenkins/inbound-agent:jdk8-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Retrieve JDK11 for running jenkins agent process but do not use it as default
+COPY --from=core C:/openjdk-11 C:/tools/jdk-11
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
 COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,5 +1,5 @@
 # escape=`
-ARG JAVA_VERSION="11.0.16_8"
+ARG JAVA_VERSION="11.0.16.1_1"
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 FROM jenkins/inbound-agent:jdk8-nanoserver-1809
 


### PR DESCRIPTION
The PR #36 introduced a regression on the JDK8 images: JDK11 was not installed anymore (ref. #32 and #35).

This PR aims to fix it + bumps the JDK11 to latest available.