### PR TITLE
chore(Updatecli): create manifests to track JDKs versions and `jenkins/inbound-agent` version

### DIFF
--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,7 +1,7 @@
 # escape=`
 ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM mcr.microsoft.com/windows/servercore:1809 as core
-FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
+FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
 
 
 # ProgressPreference => Disable Progress bar for faster downloads

--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,6 +1,8 @@
 # escape=`
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM mcr.microsoft.com/windows/servercore:1809 as core
-FROM jenkins/inbound-agent:3077.vd69cf116da_6f-3-jdk11-nanoserver-1809
+FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
+
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk11/cst-windows.yml
+++ b/maven/jdk11/cst-windows.yml
@@ -1,0 +1,11 @@
+schemaVersion: 2.0.0
+
+commandTests:
+  - name: "Check that `java` is present in the PATH and match jdk11"
+    command: "cmd.exe"
+    args: ["/C", "java", "--version"]
+    expectedOutput: ["Temurin-11"]
+  - name: "Check that `java 11` is present in C:/openjdk-11"
+    command: "cmd.exe"
+    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
+    expectedOutput: ["Temurin-11"]

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -1,8 +1,8 @@
 # escape=`
 ARG JAVA_VERSION=17.0.5_8
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -2,7 +2,8 @@
 ARG JAVA_VERSION=17.0.5_8
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:3077.vd69cf116da_6f-3-jdk11-nanoserver-1809
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
+FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -3,7 +3,7 @@ ARG JAVA_VERSION=17.0.5_8
 ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
+FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk19/Dockerfile.nanoserver
+++ b/maven/jdk19/Dockerfile.nanoserver
@@ -1,8 +1,8 @@
 # escape=`
 ARG JAVA_VERSION=19.0.1_10
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads

--- a/maven/jdk19/Dockerfile.nanoserver
+++ b/maven/jdk19/Dockerfile.nanoserver
@@ -2,7 +2,8 @@
 ARG JAVA_VERSION=19.0.1_10
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:3077.vd69cf116da_6f-3-jdk11-nanoserver-1809
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
+FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk19/Dockerfile.nanoserver
+++ b/maven/jdk19/Dockerfile.nanoserver
@@ -3,7 +3,7 @@ ARG JAVA_VERSION=19.0.1_10
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
 ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
-FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
+FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -2,7 +2,8 @@
 ARG JAVA_VERSION=8u352-b08
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:3077.vd69cf116da_6f-3-jdk11-nanoserver-1809
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
+FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,8 +1,8 @@
 # escape=`
 ARG JAVA_VERSION=8u352-b08
+ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-ARG JAVA11_IMAGE_VERSION=3077.vd69cf116da_6f-3
 FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This script checks that the provided JDK version has all the required binaries available for downloads
+# as sometimes, the tag for adoptium is published immeidatly while binaries are published later.
+##
+# The source of truth is the ERB template stored at the location dist/profile/templates/buildmaster/casc/tools.yaml.erb
+# It lists all the installations used as "Jenkins Tools" by the Jenkins controllers of the infrastructure
+##
+set -eu -o pipefail
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+
+function get_jdk_download_url() {
+  jdk_version="${1}"
+  platform="${2}"
+  case "${jdk_version}" in
+    8*)
+      ## JDK8 does not have the carret ('-') in their archive names
+      echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${jdk_version}/OpenJDK8U-jdk_${platform}_hotspot_${jdk_version//-}";
+      return 0;;
+    11*)
+      ## JDK11 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${jdk_version}/OpenJDK11U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    17*)
+      ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    19*)
+      ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    *)
+      echo "ERROR: unsupported JDK version (${jdk_version}).";
+      exit 1;;
+  esac
+}
+
+platforms=("x64_linux" "x64_windows" "aarch64_linux")
+
+for platform in "${platforms[@]}"
+do
+  url_to_check="$(get_jdk_download_url "${1}" "${platform}")"
+  if [[ "${platform}" == *windows* ]]
+  then
+    url_to_check+=".zip"
+  else
+    url_to_check+=".tar.gz"
+  fi
+  >&2 curl --connect-timeout 5 --location --head --fail --silent "${url_to_check}" || { echo "ERROR: the following URL is NOT available: ${url_to_check}."; exit 1; }
+done
+
+echo "OK: all JDK URL for version=${1} are available."

--- a/updatecli/updatecli.d/jdk11-inboundimage.yml
+++ b/updatecli/updatecli.d/jdk11-inboundimage.yml
@@ -1,0 +1,87 @@
+---
+name: Bump JDK11 version on jdk11-nanoserver-1809 (main inbound agent image)
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest jenkinsci:docker-inbound-agent
+    spec:
+      owner: "jenkinsci"
+      repository: "docker-inbound-agent"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        #3077.vd69cf116da_6f-3
+        ## not the JDK8 version - regex from https://stackoverflow.com/questions/16398471/regex-for-string-not-ending-with-given-suffix/16398502#16398502
+        pattern: '.*[^-][^j][^d][^k][^8]$'
+
+conditions:
+  checkDockerImagePublished:
+    name: "Is latest dockerfile docker-inbound-agent image published?"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      image: "jenkins/inbound-agent"
+      architecture: "amd64"
+      tag: '{{ source "lastReleaseVersion" }}-jdk11-nanoserver-1809'
+
+targets:
+  updateJDK8FileForJDK11ImgVersion:
+    name: Update the JDK11 image version
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk8/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA11_IMAGE_VERSION"
+  updateJDK11FileForJDK11ImgVersion:
+    name: Update the JDK11 image version
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk11/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA11_IMAGE_VERSION"
+  updateJDK17FileForJDK11ImgVersion:
+    name: Update the JDK11 image version
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk17/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA11_IMAGE_VERSION"
+  updateJDK19FileForJDK11ImgVersion:
+    name: Update the JDK11 image version
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk19/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA11_IMAGE_VERSION"
+
+pullrequests:
+  default:
+    kind: github
+    title: Bump JDK11 version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - jdk11

--- a/updatecli/updatecli.d/jdk17.yml
+++ b/updatecli/updatecli.d/jdk17.yml
@@ -1,0 +1,58 @@
+---
+name: Bump JDK17 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK17 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin17-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
+        # jdk-17.0.4.1+1(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.4.1%2B1) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  updateJDK17Version:
+    name: Update the JDK17 version in the Packer default values
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk17/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA_VERSION"
+
+pullrequests:
+  default:
+    kind: github
+    title: Bump JDK17 version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - jdk17

--- a/updatecli/updatecli.d/jdk19.yml
+++ b/updatecli/updatecli.d/jdk19.yml
@@ -1,0 +1,58 @@
+---
+name: Bump JDK19 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK19 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin19-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-19.0.2+8(https://github.com/adoptium/temurin19-binaries/releases/tag/jdk-19.0.2%2B8) is OK
+        # jdk-19.0.4.1+1(https://github.com/adoptium/temurin19-binaries/releases/tag/jdk-19.0.4.1%2B1) is OK
+        pattern: "^jdk-19.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  updateJDK19Version:
+    name: Update the JDK19 version in the Packer default values
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk19/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA_VERSION"
+
+pullrequests:
+  default:
+    kind: github
+    title: Bump JDK19 version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - jdk19

--- a/updatecli/updatecli.d/jdk8.yml
+++ b/updatecli/updatecli.d/jdk8.yml
@@ -1,0 +1,57 @@
+---
+    name: Bump JDK8 version
+
+    scms:
+      default:
+        kind: github
+        spec:
+          user: "{{ .github.user }}"
+          email: "{{ .github.email }}"
+          owner: "{{ .github.owner }}"
+          repository: "{{ .github.repository }}"
+          token: "{{ requiredEnv .github.token }}"
+          username: "{{ .github.username }}"
+          branch: "{{ .github.branch }}"
+
+    sources:
+      lastReleaseVersion:
+        kind: githubrelease
+        name: Get the latest Adoptium JDK8 version
+        spec:
+          owner: "adoptium"
+          repository: "temurin8-binaries"
+          token: "{{ requiredEnv .github.token }}"
+          username: "{{ .github.username }}"
+          versionfilter:
+            kind: regex
+            # (https://github.com/adoptium/temurin8-binaries/releases/tag/jdk8u345-b01) is OK but jdk8u302-b08.1 is not
+            pattern: "^jdk8u(\\d*)-b(\\d*)$"
+        transformers:
+          - trimprefix: "jdk"
+
+    conditions:
+      checkIfReleaseIsAvailable:
+        kind: shell
+        spec:
+          command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+    targets:
+      updateJDK8Version:
+        scmid: default
+        name: Update the JDK8 version in the Packer default values
+        kind: dockerfile
+        spec:
+          file: maven/jdk8/Dockerfile.nanoserver
+          instruction:
+            keyword: "ARG"
+            matcher: "JAVA_VERSION"
+
+    pullrequests:
+      default:
+        kind: github
+        title: Bump JDK8 version to {{ source "lastReleaseVersion" }}
+        scmid: default
+        spec:
+          labels:
+            - enhancement
+            - jdk8


### PR DESCRIPTION
Add manifest for jdks 8, 17 and 19. And a dedicated one for jdk11 from inbound-agent image.
also added a cst for jdk11.

This should fail test as the ARG for the jdk11 inbound image was not present on the preceding PR.