### PR TITLE
 chore(updatecli) improve Maven version tracking to track the ci.jenkins.io agent template deployed version (instead of latest) to keep environments in sync

### DIFF
--- a/updatecli/updatecli.d/jdk11-inboundimage.yml
+++ b/updatecli/updatecli.d/jdk11-inboundimage.yml
@@ -76,9 +76,9 @@ targets:
         keyword: "ARG"
         matcher: "JAVA11_IMAGE_VERSION"
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     title: Bump inbound-agent (jdk11) container image version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:

--- a/updatecli/updatecli.d/jdk17.yml
+++ b/updatecli/updatecli.d/jdk17.yml
@@ -51,9 +51,9 @@ targets:
           from: +
           to: _
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     title: Bump JDK17 version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:

--- a/updatecli/updatecli.d/jdk19.yml
+++ b/updatecli/updatecli.d/jdk19.yml
@@ -51,9 +51,9 @@ targets:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     title: Bump JDK19 version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:

--- a/updatecli/updatecli.d/jdk8.yml
+++ b/updatecli/updatecli.d/jdk8.yml
@@ -1,57 +1,57 @@
 ---
-    name: Bump JDK8 version
+name: Bump JDK8 version
 
-    scms:
-      default:
-        kind: github
-        spec:
-          user: "{{ .github.user }}"
-          email: "{{ .github.email }}"
-          owner: "{{ .github.owner }}"
-          repository: "{{ .github.repository }}"
-          token: "{{ requiredEnv .github.token }}"
-          username: "{{ .github.username }}"
-          branch: "{{ .github.branch }}"
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
 
-    sources:
-      lastReleaseVersion:
-        kind: githubrelease
-        name: Get the latest Adoptium JDK8 version
-        spec:
-          owner: "adoptium"
-          repository: "temurin8-binaries"
-          token: "{{ requiredEnv .github.token }}"
-          username: "{{ .github.username }}"
-          versionfilter:
-            kind: regex
-            # (https://github.com/adoptium/temurin8-binaries/releases/tag/jdk8u345-b01) is OK but jdk8u302-b08.1 is not
-            pattern: "^jdk8u(\\d*)-b(\\d*)$"
-        transformers:
-          - trimprefix: "jdk"
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK8 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin8-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # (https://github.com/adoptium/temurin8-binaries/releases/tag/jdk8u345-b01) is OK but jdk8u302-b08.1 is not
+        pattern: "^jdk8u(\\d*)-b(\\d*)$"
+    transformers:
+      - trimprefix: "jdk"
 
-    conditions:
-      checkIfReleaseIsAvailable:
-        kind: shell
-        spec:
-          command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
 
-    targets:
-      updateJDK8Version:
-        scmid: default
-        name: Update the JDK8 version in the Packer default values
-        kind: dockerfile
-        spec:
-          file: maven/jdk8/Dockerfile.nanoserver
-          instruction:
-            keyword: "ARG"
-            matcher: "JAVA_VERSION"
+targets:
+  updateJDK8Version:
+    scmid: default
+    name: Update the JDK8 version in the Packer default values
+    kind: dockerfile
+    spec:
+      file: maven/jdk8/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA_VERSION"
 
-    pullrequests:
-      default:
-        kind: github
-        title: Bump JDK8 version to {{ source "lastReleaseVersion" }}
-        scmid: default
-        spec:
-          labels:
-            - enhancement
-            - jdk8
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump JDK8 version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - jdk8

--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -72,9 +72,9 @@ targets:
         matcher: "MAVEN_VERSION"
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump Maven version to {{ source "mavenVersion" }}
     spec:

--- a/updatecli/updatecli.d/maven.yml
+++ b/updatecli/updatecli.d/maven.yml
@@ -14,30 +14,39 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  mavenVersion:
-    kind: githubrelease
-    name: Get the latest Maven version
+  getPackerImageDeployedVersion:
+    kind: yaml
+    name: Retrieve the current version of the Packer images used in production
     spec:
-      owner: "apache"
-      repository: "maven"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: latest
+      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+  # Retrieving Maven from packer-images to synchronize its version across our infra
+  # See https://github.com/jenkins-infra/docker-inbound-agents/issues/18
+  getMavenVersionFromPackerImages:
+    kind: file
+    name: Get the latest Maven version set in packer-images
+    dependson:
+      - getPackerImageDeployedVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
+      matchpattern: 'maven_version:\s"(.*)"'
     transformers:
-      - trimprefix: "maven-"
+      - findsubmatch:
+          pattern: 'maven_version:\s"(.*)"'
+          captureindex: 1
 
 conditions:
   checkIfReleaseIsAvailable:
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion` }}/binaries/apache-maven-{{ source `mavenVersion` }}-bin.tar.gz
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `getMavenVersionFromPackerImages` }}/binaries/apache-maven-{{ source `getMavenVersionFromPackerImages` }}-bin.tar.gz
 
 targets:
   updateMavenJdk8NanoserverVersion:
     name: Update the Maven version for the JDK8 nanoserver container image
     kind: dockerfile
+    sourceid: getMavenVersionFromPackerImages
     spec:
       file: maven/jdk8/Dockerfile.nanoserver
       instruction:
@@ -47,6 +56,7 @@ targets:
   updateMavenJdk11NanoserverVersion:
     name: Update the Maven version for the JDK11 container image
     kind: dockerfile
+    sourceid: getMavenVersionFromPackerImages
     spec:
       file: maven/jdk11/Dockerfile.nanoserver
       instruction:
@@ -56,6 +66,7 @@ targets:
   updateMavenJdk17NanoserverVersion:
     name: Update the Maven version for the JDK17 container image
     kind: dockerfile
+    sourceid: getMavenVersionFromPackerImages
     spec:
       file: maven/jdk17/Dockerfile.nanoserver
       instruction:
@@ -65,6 +76,7 @@ targets:
   updateMavenJdk19NanoserverVersion:
     name: Update the Maven version for the JDK19 container image
     kind: dockerfile
+    sourceid: getMavenVersionFromPackerImages
     spec:
       file: maven/jdk19/Dockerfile.nanoserver
       instruction:
@@ -76,7 +88,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Maven version to {{ source "mavenVersion" }}
+    title: Bump Maven version to {{ source "getMavenVersionFromPackerImages" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Closes #66.

This PR ensure that the Maven version tracked by updatecli comes from what is deployed in ci.jenkins.io (aka. the "production") instead of the latest available Maven version.

The goal is to streamlin the deployment to ci.jenkins.io: most of the builds relies on jenkins-infra/packer-images as the source of truth: the Windows agent in this repository will follow.