### PR TITLE
fix: install launchable in the final Docker layer

### DIFF
--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -4,11 +4,9 @@ ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 
-ARG LAUNCHABLE_VERSION=1.64.1
-# hadolint ignore=SC3057,DL3013
+# hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
-  pip install --no-cache-dir setuptools wheel; `
-  pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+  pip install --no-cache-dir setuptools wheel;
 
 FROM mcr.microsoft.com/windows/servercore:1809 as core
 FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
@@ -18,6 +16,10 @@ SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPrefer
 
 # Adding python
 COPY --from=python C:/Python C:/tools/python
+
+# Install Launchable in this layer
+ARG LAUNCHABLE_VERSION=1.64.1
+RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
 COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -5,11 +5,9 @@ ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 
-ARG LAUNCHABLE_VERSION=1.64.1
 # hadolint ignore=SC3057,DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
-  pip install --no-cache-dir setuptools wheel; `
-  pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+  pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
@@ -20,6 +18,10 @@ SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPrefer
 
 # Adding python
 COPY --from=python C:/Python C:/tools/python
+
+# Install Launchable in this layer
+ARG LAUNCHABLE_VERSION=1.64.1
+RUN pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Adding jdk17 from eclipse-temurin
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -5,7 +5,7 @@ ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 
-# hadolint ignore=SC3057,DL3013
+# hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
@@ -21,7 +21,7 @@ COPY --from=python C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.64.1
-RUN "C:/Python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Adding jdk17 from eclipse-temurin
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -21,7 +21,7 @@ COPY --from=python C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.64.1
-RUN pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+RUN "C:/Python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Adding jdk17 from eclipse-temurin
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables

--- a/maven/jdk19/Dockerfile.nanoserver
+++ b/maven/jdk19/Dockerfile.nanoserver
@@ -5,11 +5,9 @@ ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 
-ARG LAUNCHABLE_VERSION=1.64.1
-# hadolint ignore=SC3057,DL3013
+# hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
-  pip install --no-cache-dir setuptools wheel; `
-  pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+  pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
@@ -20,6 +18,10 @@ SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPrefer
 
 # Adding python
 COPY --from=python C:/Python C:/tools/python
+
+# Install Launchable in this layer
+ARG LAUNCHABLE_VERSION=1.64.1
+RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Retrieve JDK11 for running jenkins agent process but do not use it as default
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -5,11 +5,9 @@ ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 
-ARG LAUNCHABLE_VERSION=1.64.1
-# hadolint ignore=SC3057,DL3013
+# hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
-  pip install --no-cache-dir setuptools wheel; `
-  pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+  pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
 # Use inbound-agent's JDK11 only for running jenkins agent, not as default java
@@ -20,6 +18,10 @@ SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPrefer
 
 # Adding python
 COPY --from=python C:/Python C:/tools/python
+
+# Install Launchable in this layer
+ARG LAUNCHABLE_VERSION=1.64.1
+RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Adding jdk8 from eclipse-temurin
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables


### PR DESCRIPTION
As noted in https://github.com/jenkins-infra/helpdesk/issues/3484#issuecomment-1552280288 `launchable` isn't currently callable directly, it exits 1 without printing any output.

This PR installs `launchable` in the final layer instead of the `python` one in order to get a viable `launchable` installation.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3484