### PR TITLE
chore(updatecli) fix updatecli manifests for `0.56.x`

### DIFF
--- a/updatecli/updatecli.d/daily.d/launchable.yml
+++ b/updatecli/updatecli.d/daily.d/launchable.yml
@@ -19,7 +19,7 @@ sources:
     name: Retrieve the current version of the Packer images used in production in jenkins-infra/jenkins-infra
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   # Retrieving Launchable from packer-images to synchronize its version across our infra
   getLaunchableVersionFromDeployedPackerImages:
     kind: file

--- a/updatecli/updatecli.d/daily.d/launchable.yml
+++ b/updatecli/updatecli.d/daily.d/launchable.yml
@@ -28,10 +28,10 @@ sources:
       - getDeployedPackerImagesVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getDeployedPackerImagesVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'launchable_version:\s"(.*)"'
+      matchpattern: 'launchable_version:\s(.*)'
     transformers:
       - findsubmatch:
-          pattern: 'launchable_version:\s"(.*)"'
+          pattern: 'launchable_version:\s(.*)'
           captureindex: 1
 
 targets:

--- a/updatecli/updatecli.d/weekly.d/maven.yml
+++ b/updatecli/updatecli.d/weekly.d/maven.yml
@@ -29,10 +29,10 @@ sources:
       - getPackerImageDeployedVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'maven_version:\s"(.*)"'
+      matchpattern: 'maven_version:\s(.*)'
     transformers:
       - findsubmatch:
-          pattern: 'maven_version:\s"(.*)"'
+          pattern: 'maven_version:\s(.*)'
           captureindex: 1
 
 conditions:

--- a/updatecli/updatecli.d/weekly.d/maven.yml
+++ b/updatecli/updatecli.d/weekly.d/maven.yml
@@ -19,7 +19,7 @@ sources:
     name: Retrieve the current version of the Packer images used in production
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   # Retrieving Maven from packer-images to synchronize its version across our infra
   # See https://github.com/jenkins-infra/docker-inbound-agents/issues/18
   getMavenVersionFromPackerImages:


### PR DESCRIPTION
- The Maven and Launchable manifest are failing since 2 months
- There are 2 warnings for YAML keys to be removed