### PR TITLE
breaking: switch to JDK17 for agent processes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,6 @@
 = Inbound Agents
 
 image:https://img.shields.io/docker/pulls/jenkinsciinfra/inbound-agent-maven?label=jenkinsciinfra%2Finbound-agent-maven&logo=docker&logoColor=white[link="https://hub.docker.com/r/jenkinsciinfra/inbound-agent-maven/tags"]
-image:https://img.shields.io/docker/pulls/jenkinsciinfra/inbound-agent-node?label=jenkinsciinfra%2Finbound-agent-node&logo=docker&logoColor=white[link="https://hub.docker.com/r/jenkinsciinfra/inbound-agent-node/tags"]
 
 This repository is a collection of Docker images which combine the basics
 to run a Jenkins Inbound (formerly known as "JNLP") agents with a Docker image.

--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,5 +1,6 @@
 # escape=`
-ARG JAVA11_IMAGE_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA_VERSION=11.0.20_8
+ARG JAVA17_IMAGE_VERSION=3142.vcfca_0cd92128-1
 ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
@@ -8,8 +9,8 @@ FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
-FROM mcr.microsoft.com/windows/servercore:1809 as core
-FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk11/cst-windows.yml
+++ b/maven/jdk11/cst-windows.yml
@@ -5,7 +5,7 @@ commandTests:
     command: "cmd.exe"
     args: ["/C", "java", "--version"]
     expectedOutput: ["Temurin-11"]
-  - name: "Check that `java 11` is present in C:/openjdk-11"
+  - name: "Check that `java 17` is present in C:/openjdk-17 for agent processes"
     command: "cmd.exe"
-    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
-    expectedOutput: ["Temurin-11"]
+    args: ["/C", "C:/openjdk-17/bin/java", "--version"]
+    expectedOutput: ["Temurin-17"]

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG JAVA_VERSION=17.0.8_7
-ARG JAVA11_IMAGE_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA17_IMAGE_VERSION=3142.vcfca_0cd92128-1
 ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
@@ -10,8 +10,8 @@ RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
-# Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
+# Use inbound-agent's jdk17 only for running jenkins agent, not as default java
+FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk17/cst-windows.yml
+++ b/maven/jdk17/cst-windows.yml
@@ -5,7 +5,7 @@ commandTests:
     command: "cmd.exe"
     args: ["/C", "java", "--version"]
     expectedOutput: ["Temurin-17"]
-  - name: "Check that `java 11` is present in C:/openjdk-11"
+  - name: "Check that `java 17` is present in C:/openjdk-17 for agent processes"
     command: "cmd.exe"
-    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
-    expectedOutput: ["Temurin-11"]
+    args: ["/C", "C:/openjdk-17/bin/java", "--version"]
+    expectedOutput: ["Temurin-17"]

--- a/maven/jdk19/Dockerfile.nanoserver
+++ b/maven/jdk19/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG JAVA_VERSION=19.0.2_7
-ARG JAVA11_IMAGE_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA17_IMAGE_VERSION=3142.vcfca_0cd92128-1
 ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
@@ -10,8 +10,8 @@ RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
-# Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
+# Use inbound-agent's jdk17 only for running jenkins agent, not as default java
+FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -23,7 +23,7 @@ COPY --from=python C:/Python C:/tools/python
 ARG LAUNCHABLE_VERSION=1.65.0
 RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
-# Retrieve JDK11 for running jenkins agent process but do not use it as default
+# Retrieve jdk17 for running jenkins agent process but do not use it as default
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
 ENV JAVA_HOME="C:\tools\jdk-19"
 COPY --from=core C:/openjdk-19 "${JAVA_HOME}"

--- a/maven/jdk19/cst-windows.yml
+++ b/maven/jdk19/cst-windows.yml
@@ -5,7 +5,7 @@ commandTests:
     command: "cmd.exe"
     args: ["/C", "java", "--version"]
     expectedOutput: ["Temurin-19"]
-  - name: "Check that `java 11` is present in C:/openjdk-11"
+  - name: "Check that `java 17` is present in C:/openjdk-17 for agent processes"
     command: "cmd.exe"
-    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
-    expectedOutput: ["Temurin-11"]
+    args: ["/C", "C:/openjdk-17/bin/java", "--version"]
+    expectedOutput: ["Temurin-17"]

--- a/maven/jdk21/Dockerfile.nanoserver
+++ b/maven/jdk21/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG JAVA_VERSION=21-jdk
-ARG JAVA11_IMAGE_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA17_IMAGE_VERSION=3142.vcfca_0cd92128-1
 ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
@@ -11,8 +11,8 @@ RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
 
 ## Comment out once temurin publishes an official JDK21 container image
 #FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
-# Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:"${JAVA11_IMAGE_VERSION}"-jdk11-nanoserver-1809
+# Use inbound-agent's jdk17 only for running jenkins agent, not as default java
+FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -30,7 +30,7 @@ COPY --from=python C:/Python $pythonDir
 ARG launchableVersion=1.65.0
 RUN python.exe -m pip install --no-cache-dir launchable=="${env:launchableVersion}";
 
-# Retrieve JDK11 for running jenkins agent process but do not use it as default
+# Retrieve jdk17 for running jenkins agent process but do not use it as default
 # Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
 ENV JAVA_HOME="$toolsDir\jdk-21"
 ENV PATH="${JAVA_HOME}\bin;${PATH}"

--- a/maven/jdk21/cst-windows.yml
+++ b/maven/jdk21/cst-windows.yml
@@ -5,7 +5,7 @@ commandTests:
     command: "cmd.exe"
     args: ["/C", "java", "--version"]
     expectedOutput: ["Temurin-21"]
-  - name: "Check that `java 11` is present in C:/openjdk-11"
+  - name: "Check that `java 17` is present in C:/openjdk-17 for agent processes"
     command: "cmd.exe"
-    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
-    expectedOutput: ["Temurin-11"]
+    args: ["/C", "C:/openjdk-17/bin/java", "--version"]
+    expectedOutput: ["Temurin-17"]

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG JAVA_VERSION=8u382-b05
-ARG JAVA11_IMAGE_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA17_IMAGE_VERSION=3142.vcfca_0cd92128-1
 ARG PYTHON_VERSION=3.11.3
 
 FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
@@ -10,8 +10,8 @@ RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
 FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
-# Use inbound-agent's JDK11 only for running jenkins agent, not as default java
-FROM jenkins/inbound-agent:${JAVA11_IMAGE_VERSION}-jdk11-nanoserver-1809
+# Use inbound-agent's jdk17 only for running jenkins agent, not as default java
+FROM jenkins/inbound-agent:${JAVA17_IMAGE_VERSION}-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/maven/jdk8/cst-windows.yml
+++ b/maven/jdk8/cst-windows.yml
@@ -6,7 +6,7 @@ commandTests:
     args: ["/C", "java", "-version"]
     # JDK8 prints to `stderr` - https://bugs.openjdk.org/browse/JDK-8166116
     expectedError: ["build 1.8.", "Temurin"]
-  - name: "Check that `java 11` is present in C:/openjdk-11"
+  - name: "Check that `java 17` is present in C:/openjdk-17 for agent processes"
     command: "cmd.exe"
-    args: ["/C", "C:/openjdk-11/bin/java", "--version"]
-    expectedOutput: ["Temurin-11"]
+    args: ["/C", "C:/openjdk-17/bin/java", "--version"]
+    expectedOutput: ["Temurin-17"]

--- a/updatecli/updatecli.d/weekly.d/inboundimage.yml
+++ b/updatecli/updatecli.d/weekly.d/inboundimage.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump inbound-agent (jdk11-nanoserver-1809) container image version
+name: Bump inbound-agent (jdk17-nanoserver-1809) container image version
 
 scms:
   default:
@@ -36,50 +36,59 @@ conditions:
     spec:
       image: "jenkins/inbound-agent"
       architecture: "amd64"
-      tag: '{{ source "lastReleaseVersion" }}-jdk11-nanoserver-1809'
+      tag: '{{ source "lastReleaseVersion" }}-jdk17-nanoserver-1809'
 
 targets:
   updateJDK8:
-    name: Update inbound-agent (jdk11-nanoserver-1809) container image version for JDK8 image
+    name: Update inbound-agent (jdk17-nanoserver-1809) container image version for JDK8 image
     scmid: default
     kind: dockerfile
     spec:
       file: maven/jdk8/Dockerfile.nanoserver
       instruction:
         keyword: "ARG"
-        matcher: "JAVA11_IMAGE_VERSION"
+        matcher: "JAVA17_IMAGE_VERSION"
   updateJDK11:
-    name: Update inbound-agent (jdk11-nanoserver-1809) container image version for JDK11 image
+    name: Update inbound-agent (jdk17-nanoserver-1809) container image version for JDK11 image
     scmid: default
     kind: dockerfile
     spec:
       file: maven/jdk11/Dockerfile.nanoserver
       instruction:
         keyword: "ARG"
-        matcher: "JAVA11_IMAGE_VERSION"
+        matcher: "JAVA17_IMAGE_VERSION"
   updateJDK17:
-    name: Update inbound-agent (jdk11-nanoserver-1809) container image version for JDK17 image
+    name: Update inbound-agent (jdk17-nanoserver-1809) container image version for JDK17 image
     scmid: default
     kind: dockerfile
     spec:
       file: maven/jdk17/Dockerfile.nanoserver
       instruction:
         keyword: "ARG"
-        matcher: "JAVA11_IMAGE_VERSION"
+        matcher: "JAVA17_IMAGE_VERSION"
   updateJDK19:
-    name: Update inbound-agent (jdk11-nanoserver-1809) container image version for JDK19 image
+    name: Update inbound-agent (jdk17-nanoserver-1809) container image version for JDK19 image
     scmid: default
     kind: dockerfile
     spec:
       file: maven/jdk19/Dockerfile.nanoserver
       instruction:
         keyword: "ARG"
-        matcher: "JAVA11_IMAGE_VERSION"
+        matcher: "JAVA17_IMAGE_VERSION"
+  updateJDK21:
+    name: Update inbound-agent (jdk17-nanoserver-1809) container image version for JDK21 image
+    scmid: default
+    kind: dockerfile
+    spec:
+      file: maven/jdk21/Dockerfile.nanoserver
+      instruction:
+        keyword: "ARG"
+        matcher: "JAVA17_IMAGE_VERSION"
 
 actions:
   default:
     kind: github/pullrequest
-    title: Bump inbound-agent (jdk11) container image version to {{ source "lastReleaseVersion" }}
+    title: Bump inbound-agent (jdk17) container image version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:

--- a/updatecli/updatecli.d/weekly.d/jdk11.yml
+++ b/updatecli/updatecli.d/weekly.d/jdk11.yml
@@ -1,5 +1,5 @@
 ---
-name: Bump JDK8 version
+name: Bump JDK11 version
 
 scms:
   default:
@@ -16,18 +16,18 @@ scms:
 sources:
   lastReleaseVersion:
     kind: githubrelease
-    name: Get the latest Adoptium JDK8 version
+    name: Get the latest Adoptium JDK11 version
     spec:
       owner: "adoptium"
-      repository: "temurin8-binaries"
+      repository: "temurin11-binaries"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        # (https://github.com/adoptium/temurin8-binaries/releases/tag/jdk8u345-b01) is OK but jdk8u302-b08.1 is not
-        pattern: "^jdk8u(\\d*)-b(\\d*)$"
+        # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
+        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
-      - trimprefix: "jdk"
+      - trimprefix: "jdk-"
 
 conditions:
   checkIfReleaseIsAvailable:
@@ -36,22 +36,26 @@ conditions:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
 
 targets:
-  updateJDK8Version:
+  updateJDK11Version:
+    name: Update the JDK11 version in JDK11 Maven Nanoserver image
     scmid: default
-    name: Update the JDK8 version in the JDK8 Maven Nanoserver image
     kind: dockerfile
     spec:
-      file: maven/jdk8/Dockerfile.nanoserver
+      file: maven/jdk11/Dockerfile.nanoserver
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
+    transformers:
+      - replacer:
+          from: +
+          to: _
 
 actions:
   default:
     kind: github/pullrequest
-    title: Bump JDK8 version to {{ source "lastReleaseVersion" }}
+    title: Bump JDK11 version to {{ source "lastReleaseVersion" }}
     scmid: default
     spec:
       labels:
         - enhancement
-        - jdk8
+        - jdk11

--- a/updatecli/updatecli.d/weekly.d/jdk17.yml
+++ b/updatecli/updatecli.d/weekly.d/jdk17.yml
@@ -38,7 +38,7 @@ conditions:
 
 targets:
   updateJDK17Version:
-    name: Update the JDK17 version in the Packer default values
+    name: Update the JDK17 version in the JDK17 Maven Nanoserver image
     scmid: default
     kind: dockerfile
     spec:

--- a/updatecli/updatecli.d/weekly.d/jdk19.yml
+++ b/updatecli/updatecli.d/weekly.d/jdk19.yml
@@ -38,7 +38,7 @@ conditions:
 
 targets:
   updateJDK19Version:
-    name: Update the JDK19 version in the Packer default values
+    name: Update the JDK19 version in the JDK19 Windows Nanoserver image
     scmid: default
     kind: dockerfile
     transformers:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072, this PR switches the agents to JDK17.

Please note that is a breaking change!