### PR TITLE
chore(updatecli/python): add a target for the test harness

### DIFF
--- a/updatecli/updatecli.d/weekly.d/python3.yml
+++ b/updatecli/updatecli.d/weekly.d/python3.yml
@@ -44,6 +44,17 @@ targets:
         ARG PYTHON_VERSION=(.*)
       replacepattern: >
         ARG PYTHON_VERSION={{ source "lastReleaseVersion" }}
+  updateTestHarness:
+    name: "Update the python3 version in the test harness"
+    sourceid: lastReleaseVersion
+    scmid: default
+    kind: file
+    spec:
+      file: common-cst-windows.yml
+      matchpattern: >
+        "Python (.*)"
+      replacepattern: >
+        "Python {{ source "lastReleaseVersion" }}"
 
 actions:
   default:

--- a/updatecli/updatecli.d/weekly.d/python3.yml
+++ b/updatecli/updatecli.d/weekly.d/python3.yml
@@ -52,7 +52,7 @@ targets:
     spec:
       file: common-cst-windows.yml
       matchpattern: >
-        "Python (.*)"
+        \"Python (.*)\"
       replacepattern: >
         "Python {{ source "lastReleaseVersion" }}"
 

--- a/updatecli/updatecli.d/weekly.d/python3.yml
+++ b/updatecli/updatecli.d/weekly.d/python3.yml
@@ -52,9 +52,9 @@ targets:
     spec:
       file: common-cst-windows.yml
       matchpattern: >
-        \"Python (.*)\"
+        \["Python (.*)"]
       replacepattern: >
-        "Python {{ source "lastReleaseVersion" }}"
+        ["Python {{ source "lastReleaseVersion" }}"]
 
 actions:
   default:


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/docker-inbound-agents/pull/105#pullrequestreview-1607279004

> Looks like the [updatecli manifest tracking the python version](https://github.com/jenkins-infra/docker-inbound-agents/blob/main/updatecli/updatecli.d/weekly.d/python3.yml) does not update the [test harness](https://github.com/jenkins-infra/docker-inbound-agents/blob/09bf5618a96964950e3857a11d0381f87d573325/common-cst-windows.yml#L29)