### PR TITLE
chore(updatecli) fix python manifest to also track version for JDK21

### DIFF
--- a/updatecli/updatecli.d/weekly.d/python3.yml
+++ b/updatecli/updatecli.d/weekly.d/python3.yml
@@ -40,6 +40,7 @@ targets:
         - maven/jdk11/Dockerfile.nanoserver
         - maven/jdk17/Dockerfile.nanoserver
         - maven/jdk19/Dockerfile.nanoserver
+        - maven/jdk21/Dockerfile.nanoserver
       matchpattern: >
         ARG PYTHON_VERSION=(.*)
       replacepattern: >


### PR DESCRIPTION
Closes #113 (a new PR should be automatically created with a new branch name as the manifest content changed)