### PR TITLE
chore: fix tests on Windows

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/849/head') _
+
 properties([buildDiscarder(logRotator(daysToKeepStr: '15'))])
 
 parallel(

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,7 +6,7 @@ parallel(
     buildDockerAndPublishImage('inbound-agent-maven:jdk8-nanoserver', [
       dockerfile: 'maven/jdk8/Dockerfile.nanoserver',
       agentLabels: 'docker-windows-2019 && amd64',
-      platform: 'windows/amd64',
+      targetplatforms: 'windows/amd64',
       imageDir: 'maven/jdk8',
     ])
   },
@@ -14,14 +14,14 @@ parallel(
     buildDockerAndPublishImage('inbound-agent-maven:jdk11-nanoserver', [
       dockerfile: 'maven/jdk11/Dockerfile.nanoserver',
       agentLabels: 'docker-windows-2019 && amd64',
-      platform: 'windows/amd64',
+      targetplatforms: 'windows/amd64',
     ])
   },
   'maven-jdk17-nanoserver': {
     buildDockerAndPublishImage('inbound-agent-maven:jdk17-nanoserver', [
       dockerfile: 'maven/jdk17/Dockerfile.nanoserver',
       agentLabels: 'docker-windows-2019 && amd64',
-      platform: 'windows/amd64',
+      targetplatforms: 'windows/amd64',
       imageDir: 'maven/jdk17',
     ])
   },
@@ -29,7 +29,7 @@ parallel(
     buildDockerAndPublishImage('inbound-agent-maven:jdk21-nanoserver', [
       dockerfile: 'maven/jdk21/Dockerfile.nanoserver',
       agentLabels: 'docker-windows-2019 && amd64',
-      platform: 'windows/amd64',
+      targetplatforms: 'windows/amd64',
       imageDir: 'maven/jdk21',
     ])
   },


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4048

This PR fixes the current failures on the test phase on Windows since `container-structure-test` 1.17.0.

Note: it utilizes https://github.com/jenkins-infra/pipeline-library/pull/849 to serve as a testing PR. The `@Library` annotation will be removed on a subsequent change.

