### PR TITLE
 fix: switch to Adoptium Temurin installer instead of Docker image 

### DIFF
--- a/maven/jdk11/Dockerfile.nanoserver
+++ b/maven/jdk11/Dockerfile.nanoserver
@@ -1,34 +1,44 @@
 # escape=`
-ARG JAVA_VERSION=11.0.22_7
 ARG JAVA17_IMAGE_VERSION=3206.vb_15dcf73f6a_9-2
 ARG PYTHON_VERSION=3.12.3
 
-FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
+FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python-core
+
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
-FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+# Adding jdk11 from Adoptium MSI installer (cannot only run msiexec.exe on ServerCore, NOT on nanoserver)
+ARG JAVA_VERSION=jdk-11.0.22+7
+RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
+    $msiUrl = 'https://api.adoptium.net/v3/installer/version/{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `
+    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  'INSTALLDIR=C:\javaruntime' -Wait -Passthru ; `
+    $proc.WaitForExit() ; `
+    Remove-Item -Path C:\temp -Recurse | Out-Null
+
+# Use inbound-agent's jdk17 only for running jenkins agent, not as default java
 FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Adding python
-COPY --from=python C:/Python C:/tools/python
+COPY --from=python-core C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.66.0
 RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
-# Adding jdk11 from eclipse-temurin
-# Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
 ENV JAVA_HOME="C:\tools\jdk-11"
-COPY --from=core C:/openjdk-11 "${JAVA_HOME}"
+COPY --from=python-core C:/javaruntime $JAVA_HOME
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
-COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/whoami.exe C:/windows/system32/whoami.exe
 
 ARG MAVEN_VERSION=3.9.6
 RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/maven/jdk17/Dockerfile.nanoserver
+++ b/maven/jdk17/Dockerfile.nanoserver
@@ -1,15 +1,25 @@
 # escape=`
-ARG JAVA_VERSION=17.0.10_7
 ARG JAVA17_IMAGE_VERSION=3206.vb_15dcf73f6a_9-2
 ARG PYTHON_VERSION=3.12.3
 
-FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
+FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python-core
+
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
-FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+# Adding jdk17 from Adoptium MSI installer (cannot only run msiexec.exe on ServerCore, NOT on nanoserver)
+ARG JAVA_VERSION=jdk-17.0.10+7
+RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
+    $msiUrl = 'https://api.adoptium.net/v3/installer/version/{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `
+    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  'INSTALLDIR=C:\javaruntime' -Wait -Passthru ; `
+    $proc.WaitForExit() ; `
+    Remove-Item -Path C:\temp -Recurse | Out-Null
+
 # Use inbound-agent's jdk17 only for running jenkins agent, not as default java
 FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
@@ -17,19 +27,18 @@ FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Adding python
-COPY --from=python C:/Python C:/tools/python
+COPY --from=python-core C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.66.0
 RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
-# Adding jdk17 from eclipse-temurin
-# Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
 ENV JAVA_HOME="C:\tools\jdk-17"
-COPY --from=core C:/openjdk-17 "${JAVA_HOME}"
+COPY --from=python-core C:/javaruntime $JAVA_HOME
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
-COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/whoami.exe C:/windows/system32/whoami.exe
 
 ARG MAVEN_VERSION=3.9.6
 RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/maven/jdk21/Dockerfile.nanoserver
+++ b/maven/jdk21/Dockerfile.nanoserver
@@ -1,58 +1,50 @@
 # escape=`
-ARG JAVA_VERSION=21-jdk
 ARG JAVA17_IMAGE_VERSION=3206.vb_15dcf73f6a_9-2
 ARG PYTHON_VERSION=3.12.3
 
-FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
+FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python-core
+
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
-## Comment out once temurin publishes an official JDK21 container image
-#FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+# Adding jdk21 from Adoptium installers
+ARG JAVA_VERSION=jdk-21+35
+RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
+    $msiUrl = 'https://api.adoptium.net/v3/installer/version/{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `
+    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  'INSTALLDIR=C:\javaruntime' -Wait -Passthru ; `
+    $proc.WaitForExit() ; `
+    Remove-Item -Path C:\temp -Recurse | Out-Null
+
 # Use inbound-agent's jdk17 only for running jenkins agent, not as default java
 FROM jenkins/inbound-agent:"${JAVA17_IMAGE_VERSION}"-jdk17-nanoserver-1809
 
 # ProgressPreference => Disable Progress bar for faster downloads
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG toolsDir="C:\tools"
-ARG pythonDir="$toolsDir\python"
-
-ENV PYTHON_PATH="$pythonDir"
-ENV PATH="${pythonDir};${pythonDir}\Scripts;${PATH}"
-
 # Adding python
-COPY --from=python C:/Python $pythonDir
+COPY --from=python-core C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.66.0
-RUN python.exe -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
+RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
-# Retrieve jdk17 for running jenkins agent process but do not use it as default
-# Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
-ENV JAVA_HOME="$toolsDir\jdk-21"
-ENV PATH="${JAVA_HOME}\bin;${PATH}"
-
-## Remove once temurin publishes an official JDK21 container image
-ARG jdk21Version="2023-08-09-06-56-beta"
-# From https://github.com/jenkins-infra/packer-images/blob/f02d850cb1ce74f4cf2a03af90a5ccd06925cb5c/provisioning/windows-provision.ps1#L126
-RUN $jdk21Url = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk21-{0}/OpenJDK21U-jdk_x64_windows_hotspot_{1}.zip' -f [System.Web.HTTPUtility]::UrlEncode($env:jdk21Version),$env:jdk21Version.Replace('-beta', ''); `
-  Invoke-WebRequest -Uri "$jdk21Url" -OutFile "${env:TEMP}/temurin21.zip"; `
-  Expand-Archive -Path "${env:TEMP}/temurin21.zip" -Destination "${env:toolsDir}" ; `
-  Remove-Item ${env:TEMP}/temurin21.zip; `
-  Move-Item -Path "${env:toolsDir}\jdk-21*" -Destination "${env:JAVA_HOME}";
-
-## Comment out once temurin publishes an official JDK21 container image
-#COPY --from=core C:/openjdk-21 "${JAVA_HOME}"
+ENV JAVA_HOME="C:\tools\jdk-21"
+COPY --from=python-core C:/javaruntime $JAVA_HOME
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
-COPY --from=python C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/whoami.exe C:/windows/system32/whoami.exe
 
 ARG MAVEN_VERSION=3.9.6
 RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `
   Expand-Archive -Path "${env:TEMP}/apache-maven.zip -Destination" C:/tools ; `
   Remove-Item ${env:TEMP}/apache-maven.zip ;
+
+ENV PYTHON_PATH="C:\tools\python;C:\tools\python\Scripts"
 ENV MAVEN_HOME="C:\tools\apache-maven-${MAVEN_VERSION}"
-ENV PATH="${MAVEN_HOME}\bin;${PATH}"
+ENV PATH="${PYTHON_PATH};${JAVA_HOME}\bin;${PATH};${MAVEN_HOME}\bin;"

--- a/maven/jdk8/Dockerfile.nanoserver
+++ b/maven/jdk8/Dockerfile.nanoserver
@@ -1,15 +1,26 @@
 # escape=`
-ARG JAVA_VERSION=8u402-b06
 ARG JAVA17_IMAGE_VERSION=3206.vb_15dcf73f6a_9-2
 ARG PYTHON_VERSION=3.12.3
 
-FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python
+FROM python:"${PYTHON_VERSION}"-windowsservercore-1809 AS python-core
+
+# ProgressPreference => Disable Progress bar for faster downloads
+SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # hadolint ignore=DL3013
 RUN "C:/Python/python.exe" -m pip install --no-cache-dir --upgrade pip; `
   pip install --no-cache-dir setuptools wheel;
 
-FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809 AS core
+# Adding jdk8 from Adoptium MSI installer (cannot only run msiexec.exe on ServerCore, NOT on nanoserver)
+# WARNING: JDK8 has a different URL pattern than the others (/jdk8<...>/ instead of /jdk-17<...>/)
+ARG JAVA_VERSION=jdk8u402-b06
+RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
+    $msiUrl = 'https://api.adoptium.net/v3/installer/version/{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `
+    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  'INSTALLDIR=C:\javaruntime' -Wait -Passthru ; `
+    $proc.WaitForExit() ; `
+    Remove-Item -Path C:\temp -Recurse | Out-Null
+
 # Use inbound-agent's jdk17 only for running jenkins agent, not as default java
 FROM jenkins/inbound-agent:${JAVA17_IMAGE_VERSION}-jdk17-nanoserver-1809
 
@@ -17,19 +28,19 @@ FROM jenkins/inbound-agent:${JAVA17_IMAGE_VERSION}-jdk17-nanoserver-1809
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Adding python
-COPY --from=python C:/Python C:/tools/python
+COPY --from=python-core C:/Python C:/tools/python
 
 # Install Launchable in this layer
 ARG LAUNCHABLE_VERSION=1.66.0
 RUN "C:/tools/python/python.exe" -m pip install --no-cache-dir launchable=="${env:LAUNCHABLE_VERSION}";
 
 # Adding jdk8 from eclipse-temurin
-# Use ENV and not ARG : https://docs.docker.com/engine/reference/builder/#using-arg-variables
 ENV JAVA_HOME="C:\tools\jdk-8"
-COPY --from=core C:/openjdk-8 "${JAVA_HOME}"
+COPY --from=python-core C:/javaruntime $JAVA_HOME
 
 # https://github.com/StefanScherer/dockerfiles-windows/tree/master/golang-issue-21867
-COPY --from=core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/netapi32.dll C:/windows/system32/netapi32.dll
+COPY --from=python-core C:/windows/system32/whoami.exe C:/windows/system32/whoami.exe
 
 ARG MAVEN_VERSION=3.9.6
 RUN Invoke-WebRequest -Uri "https://archive.apache.org/dist/maven/maven-3/${env:MAVEN_VERSION}/binaries/apache-maven-${env:MAVEN_VERSION}-bin.zip" -OutFile ${env:TEMP}/apache-maven.zip ; `


### PR DESCRIPTION
This PR aims at fixing the build failures on #150 #151 and #152 (ref. https://github.com/jenkins-infra/helpdesk/issues/4058) as the Docker images of Adoptium Temurin are not available for the last JDK versions, by using the Temurin installer instead of the docker image. Inspired by https://github.com/jenkinsci/docker-agent/pull/787

It introduces the following changes:

- Installation of the adoptium MSIs happens in the `python-core` stage which uses a Windows Server Core base: `misexec.exe` does not exist on Nanoserver.
    - Moving `ARG JAVA_VERSION` into the Python stage's scope as a consequence to avoid repetition out and in the scope
    - The JDK versions specified by the `ARG JAVA_VERSION` build arguments is changed to allow using the same download code (for future factorization), which breaks the `updatecli` for now (see notes below):
    - The prefix `jdk-` is added for JDK11, JDK17 and JDK21. The prefix `jdk` is added for JDK8.
    - The character `+` is usedinstead of `_` to avoid further transformations: the Docker images where using `_` for their tags
- Faster build due to less layers to pull (ref. https://github.com/jenkinsci/docker-agent/pull/787)
- Retrieving the `netapi32` DLL and `whoami.exe`` from the Python parent image instead of Temurin image
- Pin JDK21 version to 21+35 to ensure a valid installer is retrieved
- Cleanups to ensure the 4 `Dockerfile`s are as close as possible

----

Notes:


- No `updatecli` manifests are changed: This PR breaks the current manifests. A subsequent PR is required to fix them.
- No `jlink` to "tune" the JDK but can be done on subsequent PR (cc @lemeurherve for info). But the JDK is installed into `C:\javaruntime` which is static.
- No factorization (yet?) as the pipeline library does not support passing custom build arguments to `docker build`, it does not support `docker-compose.yml` and Windows container do not work with Docker BuildX.

