### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -33,13 +33,4 @@ parallel(
       imageDir: 'maven/jdk21',
     ])
   },
-  'updatecli': {
-    // Test all configs
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-      // Execute config daily or weekly depending on their folder
-      updatecli(action: 'apply', config: './updatecli/updatecli.d/daily.d', cronTriggerExpression: '@daily')
-      updatecli(action: 'apply', config: './updatecli/updatecli.d/weekly.d', cronTriggerExpression: '@weekly')
-    }
-  },
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,6 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+      // Execute config daily or weekly depending on their folder
+      updatecli(action: 'apply', config: './updatecli/updatecli.d/daily.d', cronTriggerExpression: '@daily')
+      updatecli(action: 'apply', config: './updatecli/updatecli.d/weekly.d', cronTriggerExpression: '@weekly')
+}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -2,7 +2,6 @@
 github:
   user: "jenkins-infra-updatecli"
   email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
-  username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778